### PR TITLE
로그아웃 API 구현 완료

### DIFF
--- a/server/src/controllers/authCtrl.js
+++ b/server/src/controllers/authCtrl.js
@@ -14,9 +14,10 @@ const authCtrl = {
                          secure: true,
                          maxAge: 60 * 60 * 24 * 14,   // 쿠키의 유효 기간을 14일로 설정
                     });
+                    console.log(response.refreshToken)
                }
                responseUtils.createResponse(res, response);
-          } catch(err) {
+          }catch(err) {
                responseUtils.createResponse(res, {code: 500});
           };
      },
@@ -30,7 +31,18 @@ const authCtrl = {
           }catch(err) {
                responseUtils.createResponse(res, {code: 500});
           };
-     }
+     },
+     logout: async (req, res) => {  
+          const user_id = req.user.user_id;  // JWT 미들웨어로부터 받은 인증된 사용자 아이디
+          const refreshToken = req.cookies.refreshToken;  
+          try {
+               const auth = new Auth({user_id, refreshToken});
+               const response =  await auth.logout();
+               responseUtils.createResponse(res, response);
+          }catch(err) {
+               responseUtils.createResponse(res, {code: 500});
+          }
+     },
 };
 
 module.exports = authCtrl;

--- a/server/src/models/authModel.js
+++ b/server/src/models/authModel.js
@@ -16,8 +16,7 @@ class Auth {
             const {user_id, password} = findUser;             
             if(client.user_id === user_id && client.password === password) {  // 입력한 아이디와 비밀번호가 모두 일치한 경우
                 const accessToken = jwtUtils.sign({user_id: user_id}); 
-                const refreshToken = jwtUtils.sign({}, {expiresIn: "14d"});   // 유효기간을 2주로 설정
-                
+                const refreshToken = jwtUtils.sign({}, {expiresIn: "14d"});   // 유효기간을 2주로 설정s
                 await authStorage.insertRefresh(user_id, refreshToken);
                 return { code: 200, data: {accessToken : accessToken }, refreshToken};
             }
@@ -46,6 +45,16 @@ class Auth {
     
         return { code: 403, message: "refreshToken이 유효하지 않습니다." };
     };
+
+    async logout() {
+        const { user_id, refreshToken } = this.body;
+        const result = await authStorage.findRefresh(user_id, refreshToken);
+        if (!result){
+            return { code: 400, message: "이미 로그아웃이 완료된 사용자입니다."};
+        }
+        await authStorage.deleteRefresh(user_id, refreshToken);
+        return { code: 200 };
+    }
 }
 
 module.exports = Auth;

--- a/server/src/models/authStorage.js
+++ b/server/src/models/authStorage.js
@@ -16,6 +16,19 @@ class authStorage {
         const query = "INSERT INTO AuthToken (user_id, refresh_token) VALUES(?, ?);"
         await db.connection(query, [user_id, refreshToken]);
     }
+
+    // 로그아웃 시 해당 사용자의 refreshToken을 삭제
+    static async deleteRefresh(user_id, refreshToken) {
+        const query = "DELETE FROM AuthToken WHERE user_id = ? AND refresh_token = ?;";
+        await db.connection(query, [user_id, refreshToken]);
+    }
+
+    // 사용자의 refreshToken 존재 유무 확인
+    static async findRefresh(user_id, refreshToken) {
+        const query = "SELECT * FROM AuthToken WHERE user_id = ? AND refresh_token = ?;";
+        const result = await db.connection(query, [user_id, refreshToken]);
+        return result;
+    }
 };
 
 module.exports = authStorage;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -4,8 +4,12 @@ const router = express.Router();
 // 컨트롤러
 const authCtrl = require("../controllers/authCtrl");
 
+// JWT 미들웨어
+const authToken = require("../middlewares/authToken");
+
 // 라우터
 router.post("/login", authCtrl.login);
 router.post("/tokens", authCtrl.refresh)
+router.delete("/logout", authToken, authCtrl.logout);
 
 module.exports = router;


### PR DESCRIPTION
- JWT 미들웨어를 통해 인증된 사용자의 아이디와 브라우저의 쿠키에 저장된 refreshToken을 이용하여 로그아웃 로직 수행
-  로그아웃 요청 시, 해당 사용자의 refreshToken을 삭제
-  refreshToken을 삭제하기 전 사용자의 refreshToken이 존재하는지 확인하고, 없을 경우 이미 로그아웃 된 사용자로 간주하고 실패 응답을 반환