### PR TITLE
 JWT 미들웨에 수행 중 요청 헤더에 accessToken이 없을 경우 발생하는 오류 수정

### DIFF
--- a/server/src/middlewares/authToken.js
+++ b/server/src/middlewares/authToken.js
@@ -7,7 +7,7 @@ const authToken = (req, res, next) => {
 
     if(!authHeader || !authHeader.startsWith('Bearer ')) {
         const response = {code: 401, message: "로그인을 해주세요."};
-        responseUtils.createResponse(res, response);
+        return responseUtils.createResponse(res, response);
     }
 
     // Authorization 헤더에서 토큰 추출


### PR DESCRIPTION
- accessToekn이 없는 경우, 실패 응답과 함께 미들웨어가 즉시 종료되도록 수정