### PR TITLE
이미지 파일명 한글 깨짐 오류 수정

### DIFF
--- a/server/src/utils/s3Utils.js
+++ b/server/src/utils/s3Utils.js
@@ -12,7 +12,7 @@ module.exports = {
 
     // s3에 사용자 이미지 저장
     uploadImage: async (baseFolder, image, user_id, date) => {
-        const fileName = Buffer.from(image.originalname, 'utf8').toString('utf8'); // 한글 깨짐 방지
+        const fileName = Buffer.from(image.originalname, "latin1").toString("utf8"); // 한글 깨짐 방지
         const path = `${baseFolder}/${user_id}/${fileName}_${date}`; // 날짜와 파일명을 포함한 경로
         
         const command =  new PutObjectCommand({


### PR DESCRIPTION
- 사용자로부터 전달 받은 이미지 파일명이 한글인 경우 깨지는 오류 재발생
- 파일명을 latin1로 디코딩한 뒤, 이를 utf8로 변환하는 방법으로 변경