### PR TITLE
카카오 로그인 기능 구현

### DIFF
--- a/client/src/api/login.js
+++ b/client/src/api/login.js
@@ -6,3 +6,8 @@ export const postLogin = async (userData) => {
         const response = await axios.post(`${SERVER_URL}/login`, userData);
         return response;
 };
+
+export const kakaoLogin = async (code) => {
+        const response = await axios.post(`${SERVER_URL}/login/kakao/${code}`);
+        return response;
+}

--- a/client/src/components/login/KaKao.jsx
+++ b/client/src/components/login/KaKao.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import UserContext from 'contexts/UserContext';
+import { kakaoLogin } from "api/login";
+
+const Kakao = () => {
+    const navigate = useNavigate();
+    const redirectCode = new URL(window.location.href).searchParams.get("code");
+    const { setUser } = useContext(UserContext);
+
+    const login = async () => {
+        try {
+            const response = await kakaoLogin(redirectCode);
+            const { accessToken, user_id } = response.data.success;
+            localStorage.setItem("accessToken", accessToken);
+            setUser(user_id);
+            navigate("/home"); 
+        } catch (err) {
+            console.log(err.response.data.error);
+        }
+    };
+
+    useEffect(() => {
+        login(); 
+    }, []);
+
+    return (
+        <>
+          
+        
+        </>
+    );
+};
+
+export default Kakao;

--- a/client/src/components/start/LoginLink.jsx
+++ b/client/src/components/start/LoginLink.jsx
@@ -1,29 +1,53 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+const REST_API_KEY = process.env.REACT_APP_REST_API_KEY;
+const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
+const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
 const LoginLink = () => {
+
+  const handleKaKaoLogin = () => {
+    window.location.href = kakaoURL; // 로그인 창 열기
+  };
+
   return(
-    <StyledLink to="/login">아이디/비밀번호 로그인</StyledLink>
+    <LinkContainer>
+      <StyledLink to="/login">아이디/비밀번호 로그인</StyledLink>
+      <KaKaoButton onClick={handleKaKaoLogin} />
+    </LinkContainer>
   );
 };
 
 
 export default LoginLink;
 
-const StyledLink = styled(Link)`
-    position: absolute;
-    bottom: 20%;
-    padding: 10px 20px;
-    width: 300px;
-    font-size: 20px;
-    font-weight: 700;
-    color: ${(props) => props.theme.text};
-    text-align: center;
-    border: 3px dashed ${(props) => props.theme.line1};
-    border-radius: 12px;
-    background-color: rgba(248, 243, 233, 0.418);
-
-    &:hover {
-      background-color: ${(props) => props.theme.bt_darkbg};
-    }
+const LinkContainer = styled.div`
+   position: absolute;
+   display: flex;
+   flex-direction: column;
+   bottom: 20%;
+   width: 300px;
+   gap: 20px;
 `;
+
+const StyledLink = styled(Link)`
+  padding: 10px 20px;
+  width: 100%;
+  font-size: 20px;
+  font-weight: 700;
+  color: ${(props) => props.theme.text};
+  text-align: center;
+  border: 3px dashed ${(props) => props.theme.line1};
+  background-color: rgba(248, 243, 233, 0.418);
+  border-radius: 12px;
+  &:hover {
+    background-color: ${(props) => props.theme.bt_darkbg};
+  }
+`;
+
+const KaKaoButton = styled.button`
+  width: 100%;
+  height: 50px;
+  background: url("https://diary-project-images.s3.ap-northeast-2.amazonaws.com/frontend/%EC%B9%B4%EC%B9%B4%EC%98%A4+%EB%A1%9C%EA%B7%B8%EC%9D%B8+%EB%B2%84%ED%8A%BC+%EC%9D%B4%EB%AF%B8%EC%A7%80");
+  background-repeat: no-repeat;
+`

--- a/client/src/routes/Router.jsx
+++ b/client/src/routes/Router.jsx
@@ -6,6 +6,7 @@ import SignUpPage from "pages/SignUpPage";
 import DiaryPage from "pages/DiaryPage";
 import HomePage from "pages/HomePage";
 import GraphPage from "pages/GraphPage";
+import Kakao from "components/login/KaKao";
 
 const Router = () => {
     return(
@@ -16,6 +17,7 @@ const Router = () => {
             <Route path="/diary" element={<DiaryPage />} />
             <Route path="/home" element={<HomePage />} />
             <Route path="/graph" element={<GraphPage />} />
+            <Route path="/oauth/callback/kakao" element={<Kakao />}/>
         </Routes>
     )
 };

--- a/server/src/controllers/authCtrl.js
+++ b/server/src/controllers/authCtrl.js
@@ -43,6 +43,16 @@ const authCtrl = {
                responseUtils.createResponse(res, {code: 500});
           }
      },
+     kakaoLogin: async (req, res) => {
+          const code = req.params.code;
+          try {
+               const auth = new Auth(code);
+               const response = await auth.kakaoLogin();
+               responseUtils.createResponse(res, response);
+          }catch(err) {
+               responseUtils.createResponse(res, {code: 500});
+          }
+     }
 };
 
 module.exports = authCtrl;

--- a/server/src/models/authStorage.js
+++ b/server/src/models/authStorage.js
@@ -30,6 +30,12 @@ class authStorage {
         const result = await db.connection(query, [user_id, refreshToken]);
         return result;
     }
+
+    static async insertKakaoUser(userData) {
+        const {user_id, user_name, image} = userData;
+        const query = "INSERT INTO User (user_id, user_name, profile_image) VALUES(?, ?, ?);"
+        await db.connection(query, [user_id, user_name, image]);
+    }
 };
 
 module.exports = authStorage;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -9,6 +9,7 @@ const authToken = require("../middlewares/authToken");
 
 // 라우터
 router.post("/login", authCtrl.login);
+router.post("/login/kakao/:code", authCtrl.kakaoLogin);
 router.post("/tokens", authCtrl.refresh)
 router.delete("/logout", authToken, authCtrl.logout);
 

--- a/server/src/utils/kakaoUtils.js
+++ b/server/src/utils/kakaoUtils.js
@@ -1,0 +1,37 @@
+const axios = require("axios");
+
+module.exports = {
+    // 전달 받은 인가 코드를 이용해서 카카오 서버로부터 토큰 발급 받기
+    getAccessToken: async (code) => {
+        try {
+            const response = await axios.post("https://kauth.kakao.com/oauth/token", null, {
+                headers: {
+                    "Content-Type" : "application/x-www-form-urlencoded;charset=utf-8"
+                },
+                params: {
+                    grant_type: "authorization_code",
+                    client_id: process.env.KAKAO_ID,
+                    redirect_uri: process.env.KAKAO_REDIRECT_URI,
+                    code: code
+                }
+            });
+            token = response.data.access_token;
+            return token;
+        } catch(err) {
+            console.log(err);
+        };
+    },
+    // accessToken을 이용하여 카카오 서버로부터 사용자 정보 받기
+    getUserInfo: async (token) => {
+         try {
+            const user = await axios.get("https://kapi.kakao.com/v2/user/me", {
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                },
+            });
+            return user.data;
+        }catch(err) {
+            console.log(err);
+        }
+    }
+};


### PR DESCRIPTION
- 프론트엔드, 백엔드 카카오 로그인 기능 로직 구현 완료
- 사업자 정보를 등록하고 비즈니스 인증을 하지 않을 경우 카카오 서버로부터 받을 수 있는 사용자의 정보가 회원번호, 닉네임, 프로필 이미지로 제한됩니다.  따라서 db에는 이메일과 비밀번호가 저장되지 않도록 User 테이블의 email, password의 제약조건을 변경했습니다.