### PR TITLE
accessToken 만료 시 로그인 화면으로 이동하는 로직 구현

### DIFF
--- a/client/src/api/calendar.js
+++ b/client/src/api/calendar.js
@@ -1,11 +1,7 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const getMonthEmoji = async (userData) => {
     const {user_id, date} = userData;
-    const response = await axios.get(`${SERVER_URL}/analysis/month/${user_id}/${date}`,{
-        headers: {"Authorization": `Bearer ${localStorage.getItem("accessToken")}`}
-    });
+    const response = await api.get(`/analysis/month/${user_id}/${date}`);
     return response;
 }

--- a/client/src/api/diary.js
+++ b/client/src/api/diary.js
@@ -1,41 +1,29 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const postDiary = async (formData) => {
-        const response = await axios.post(`${SERVER_URL}/diary`, formData,{
-                headers: { 'Content-Type': 'multipart/form-data' ,
-                           'Authorization': `Bearer ${localStorage.getItem("accessToken")}`
-                         },
+        const response = await api.post("/diary", formData,{
+                headers: { 'Content-Type': 'multipart/form-data' }            
         });
         return response;
 };
 
 export const putEdit = async (diaryData, userData) => {
         const {user_id, date} = userData;
-        const response = await axios.put(`${SERVER_URL}/diary/${user_id}/${date}`, diaryData, {
-                headers: { 'Content-Type': 'multipart/form-data',
-                           'Authorization': `Bearer ${localStorage.getItem("accessToken")}`
-                         },
+        const response = await api.put(`/diary/${user_id}/${date}`, diaryData, {
+                headers: { 'Content-Type': 'multipart/form-data' }
         });
         return response;
 };
 
 export const getView = async (userData) => {
         const {user_id, date} = userData;
-        const response = await axios.get(`${SERVER_URL}/diary/${user_id}/${date}`, {
-                headers: { 'Authorization': `Bearer ${localStorage.getItem("accessToken")}`
-                         },
-        });
+        const response = await api.get(`/diary/${user_id}/${date}`);
         return response;
 };
 
 export const deleteDiary = async (userData) => {
         const {user_id, date} = userData;
-        const response = await axios.delete(`${SERVER_URL}/diary/${user_id}/${date}`, {
-                headers: { 'Authorization': `Bearer ${localStorage.getItem("accessToken")}`
-                         },
-        });
+        const response = await api.delete(`/diary/${user_id}/${date}`);
         return response;
 };
         

--- a/client/src/api/email.js
+++ b/client/src/api/email.js
@@ -1,12 +1,10 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const checkEmailDuplication = async (email) => {
     try {
-        const response = await axios.get(`${SERVER_URL}/users/email/${email}`);
+        const response = await api.get(`/users/email/${email}`);
         return response.status;
     } catch (error) {
-        throw error
+        throw error;
     }
 };

--- a/client/src/api/graph.js
+++ b/client/src/api/graph.js
@@ -1,11 +1,7 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const getScore = async (userData) => {
     const {user_id, date} = userData;
-    const response = await axios.get(`${SERVER_URL}/analysis/score/${user_id}/${date}`,{
-        headers: {"Authorization": `Bearer ${localStorage.getItem("accessToken")}`}
-    });
+    const response = await api.get(`/analysis/score/${user_id}/${date}`);
     return response;
 }

--- a/client/src/api/id.js
+++ b/client/src/api/id.js
@@ -1,10 +1,8 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const checkIdDuplication = async (user_id) => {
     try {
-        const response = await axios.get(`${SERVER_URL}/users/id/${user_id}`);
+        const response = await api.get(`/users/id/${user_id}`);
         return response.status;
     } catch (error) {
         throw error

--- a/client/src/api/login.js
+++ b/client/src/api/login.js
@@ -1,13 +1,11 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const postLogin = async (userData) => {
-        const response = await axios.post(`${SERVER_URL}/login`, userData);
+        const response = await api.post("/login", userData);
         return response;
 };
 
 export const kakaoLogin = async (code) => {
-        const response = await axios.post(`${SERVER_URL}/login/kakao/${code}`);
+        const response = await api.post(`/login/kakao/${code}`);
         return response;
 }

--- a/client/src/api/token.js
+++ b/client/src/api/token.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+const api = axios.create({
+    baseURL: process.env.REACT_APP_SERVER_URL,
+});
+
+
+// 요청 인터셉터
+api.interceptors.request.use(
+    config => {
+        const accessToken = localStorage.getItem("accessToken");
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        return config;
+    },
+    error => {
+        return Promise.reject(error);
+    }
+);
+
+// 응답 인터셉터
+api.interceptors.response.use(
+    response => response,
+    async error => {
+        if(error.response?.status === 401) {
+            try {
+                window.location.href = "/";
+            } catch(err) {
+                return Promise.reject(err);
+            }
+        };
+        return Promise.reject(error);
+    }
+);
+
+export default api;

--- a/client/src/api/user.js
+++ b/client/src/api/user.js
@@ -1,8 +1,6 @@
-import axios from 'axios';
-
-const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+import api from "api/token";
 
 export const registerUser = async (userData) => {
-    const response = await axios.post(`${SERVER_URL}/users`, userData);
+    const response = await api.post("/users", userData);
     return response;
 };

--- a/server/src/controllers/authCtrl.js
+++ b/server/src/controllers/authCtrl.js
@@ -11,10 +11,10 @@ const authCtrl = {
                     // RefreshToken을 쿠키로 넘김
                     res.cookie("refreshToken", response.refreshToken, {
                          httpOnly: true,
-                         secure: true,
-                         maxAge: 60 * 60 * 24 * 14,   // 쿠키의 유효 기간을 14일로 설정
+                         secure: false,
+                         sameSite: "Lax",
+                         maxAge: 60 * 60 * 24 * 14 * 1000,
                     });
-                    console.log(response.refreshToken)
                }
                responseUtils.createResponse(res, response);
           }catch(err) {

--- a/server/src/middlewares/authToken.js
+++ b/server/src/middlewares/authToken.js
@@ -19,7 +19,7 @@ const authToken = (req, res, next) => {
         next();     // 다음 미들웨어로 이동
     } 
     else {
-        const response = {code: 403, message: "accessToken이 만료되었습니다."};
+        const response = {code: 401, message: "accessToken이 만료되었습니다."};
         responseUtils.createResponse(res, response);
     }
 };


### PR DESCRIPTION
- https 환경이 아닌 경우 브라우저에 쿠키를 저장하기 어려울 것 같습니다. 따라서 refreshToken을 이용해서 accessToken을 재발급 받는 로직을 구현할 수가 없어 accessToken의 유효 시간을 2주로 늘린 후, 만료될 경우 로그인 화면으로 이동하도록 구현 했습니다.